### PR TITLE
Multidb support Take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,20 @@ def my_function():
 	...
 ```
 
+
 This will raise `massmigration.exceptions.RequiredMigrationNotApplied` if the function is called before the migration is applied.
 
-Notes:
+### Multiple DBs Support
+When running on multiple databases, by default, the utilities assume that the migration is ran on all the databases specified by the Migration `allowed_db_aliases` attribute.
+To customise that behaviour the decorators accept an optional `db_aliases` list to specify a subset of the aliases allowed for the migration and require only those to have been applied.
+
+```python
+@requires_migration(("myapp", "0001_my_migration"), db_aliases=["my_db_alias"])
+def my_function():
+	...
+```
+
+### Notes:
 * If the migration _is_ applied, then this will cache that fact, so it will only query the database the first time the function is called.
 * The migration identifier can either be a tuple of `(app_label, migration_name)` or can be a string of `"app_label:migration_name"`.
 * There is an optional second argument `skip_in_tests`, which defaults to `True`.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ If you want to take matters into your own hands you can write an entirely custom
 These can still be tracked the same as the other operations, but the implementation of what your migration
 does and how your the backend handles it are up to you.
 
+Running with Multiple DBs
+-------------------
+If your projects connects to multiple databases it is possible to run your migrations against all of them singularly.
+The migrations are not forced on a specific DB but rather the `db_alias` is passed to both to `get_queryset(db_alias)` (for mappers migrations) and `operation` (for simple migrations) giving control back to the developer to customise what is retrieved for the migration.
+
+By default a migration can be run on any available database. That can be customised but setting `allowed_db_aliases` on the migration class.
+
 
 Applying Migrations
 -------------------

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ does and how your the backend handles it are up to you.
 
 Running with Multiple DBs
 -------------------
-If your projects connects to multiple databases it is possible to run your migrations against all of them singularly.
+If your project connects to multiple databases it is possible to run your migrations against each database individually.
 The migrations are not forced on a specific DB but rather the `db_alias` is passed to both to `get_queryset(db_alias)` (for mappers migrations) and `operation` (for simple migrations) giving control back to the developer to customise what is retrieved for the migration.
 
 By default a migration can be run on any available database. That can be customised but setting `allowed_db_aliases` on the migration class.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ def my_function():
 This will raise `massmigration.exceptions.RequiredMigrationNotApplied` if the function is called before the migration is applied.
 
 ### Multiple DBs Support
-When running on multiple databases, by default, the utilities assume that the migration is ran on all the databases specified by the Migration `allowed_db_aliases` attribute.
+When running on multiple databases, by default, the utilities assume that the migration must have been applied on all the databases specified by the Migration's `allowed_db_aliases` attribute.
 To customise that behaviour the decorators accept an optional `db_aliases` list to specify a subset of the aliases allowed for the migration and require only those to have been applied.
 
 ```python

--- a/massmigration/api.py
+++ b/massmigration/api.py
@@ -46,5 +46,5 @@ def can_start_migration(migration: BaseMigration, db_alias: str) -> bool:
 
 def initiate_migration(migration: BaseMigration, db_alias: str) -> bool:
     if migration_is_in_progress(migration):
-        raise MigrationAlreadyStarted(f"Migration {migration.key} on db <{{db_alias}}> is already running.")
+        raise MigrationAlreadyStarted(f"Migration {migration.key} on db '{db_alias}' is already running.")
     migration.launch(db_alias)

--- a/massmigration/api.py
+++ b/massmigration/api.py
@@ -18,33 +18,33 @@ def get_all_migrations() -> List[BaseMigration]:
     return store.all
 
 
-def migration_is_applied(migration: BaseMigration) -> bool:
+def migration_is_applied(migration: BaseMigration, db_alias: str) -> bool:
     """ Is the given migration applied? """
-    return enforcement.migration_is_applied(migration.key)
+    return enforcement.migration_is_applied(migration.key, db_alias)
 
 
-def migration_was_started(migration: BaseMigration) -> bool:
+def migration_was_started(migration: BaseMigration, db_alias: str) -> bool:
     """ Has the given migration ever been initiated (even if it hasn't finished or it failed)? """
-    return MigrationRecord.objects.filter(key=migration.key).exists()
+    return MigrationRecord.objects.using(db_alias).filter(key=migration.key).exists()
 
 
-def migration_is_in_progress(migration: BaseMigration) -> bool:
+def migration_is_in_progress(migration: BaseMigration, db_alias: str) -> bool:
     """ Is the given migration currently running (started but not yet finished and not errored)? """
-    return MigrationRecord.objects.filter(
+    return MigrationRecord.objects.using(db_alias).filter(
         key=migration.key, is_applied=False, has_error=False
     ).exists()
 
 
-def can_start_migration(migration: BaseMigration) -> bool:
+def can_start_migration(migration: BaseMigration, db_alias: str) -> bool:
     """ Can the given migration be started? I.e. either it's never been started or all previous
         attempts have errored.
     """
-    return not MigrationRecord.objects.filter(key=migration.key).exclude(
+    return not MigrationRecord.objects.using(db_alias).filter(key=migration.key).exclude(
         has_error=True
     ).exists()
 
 
-def initiate_migration(migration: BaseMigration) -> bool:
+def initiate_migration(migration: BaseMigration, db_alias: str) -> bool:
     if migration_is_in_progress(migration):
-        raise MigrationAlreadyStarted(f"Migration {migration.key} is already running.")
-    migration.launch()
+        raise MigrationAlreadyStarted(f"Migration {migration.key} on db <{{db_alias}}> is already running.")
+    migration.launch(db_alias)

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -39,7 +39,7 @@ class DjangaeBackend(BackendBase):
         # is appropriate for the DB.
         queryset = migration.get_queryset()
         key_ranges_getter = self._key_ranges_getter(queryset)
-        with get_transaction(using=db_alias).atomic():
+        with get_transaction().atomic(using=db_alias):
             attempt_uuid = migration.mark_as_started(db_alias)
             defer_iteration_with_finalize(
                 queryset,

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -30,11 +30,11 @@ class DjangaeBackend(BackendBase):
         Works with SQL, Cloud Datastore and Firestore.
     """
 
-    def run_simple(self, migration, db_alias=None):
+    def run_simple(self, migration, db_alias):
         defer(migration.wrapped_operation, db_alias, _queue=self._get_queue_name(migration), _using=db_alias)
         logger.info("Deferred task to run single-task migration %s", migration.key)
 
-    def run_mapper(self, migration, db_alias=None):
+    def run_mapper(self, migration, db_alias):
         # Use `defer_iteration_with_finalize` to do the processing with whichever key_ranges_getter
         # is appropriate for the DB.
         queryset = migration.get_queryset(db_alias)

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -30,8 +30,8 @@ class DjangaeBackend(BackendBase):
         Works with SQL, Cloud Datastore and Firestore.
     """
 
-    def run_simple(self, migration):
-        defer(migration.wrapped_operation, _queue=self._get_queue_name(migration))
+    def run_simple(self, migration, db_alias=None):
+        defer(migration.wrapped_operation, db_alias, _queue=self._get_queue_name(migration))
         logger.info("Deferred task to run single-task migration %s", migration.key)
 
     def run_mapper(self, migration, db_alias=None):

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -31,7 +31,7 @@ class DjangaeBackend(BackendBase):
     """
 
     def run_simple(self, migration, db_alias=None):
-        defer(migration.wrapped_operation, db_alias, _queue=self._get_queue_name(migration))
+        defer(migration.wrapped_operation, db_alias, _queue=self._get_queue_name(migration), _using=db_alias)
         logger.info("Deferred task to run single-task migration %s", migration.key)
 
     def run_mapper(self, migration, db_alias=None):

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -37,7 +37,7 @@ class DjangaeBackend(BackendBase):
     def run_mapper(self, migration, db_alias=None):
         # Use `defer_iteration_with_finalize` to do the processing with whichever key_ranges_getter
         # is appropriate for the DB.
-        queryset = migration.get_queryset()
+        queryset = migration.get_queryset(db_alias)
         key_ranges_getter = self._key_ranges_getter(queryset)
         with get_transaction().atomic(using=db_alias):
             attempt_uuid = migration.mark_as_started(db_alias)

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -37,9 +37,9 @@ class DjangaeBackend(BackendBase):
     def run_mapper(self, migration, db_alias=None):
         # Use `defer_iteration_with_finalize` to do the processing with whichever key_ranges_getter
         # is appropriate for the DB.
-        queryset = migration.get_queryset().using(db_alias)
+        queryset = migration.get_queryset()
         key_ranges_getter = self._key_ranges_getter(queryset)
-        with get_transaction().atomic():
+        with get_transaction(using=db_alias).atomic():
             attempt_uuid = migration.mark_as_started(db_alias)
             defer_iteration_with_finalize(
                 queryset,

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -39,7 +39,7 @@ class DjangaeBackend(BackendBase):
         # is appropriate for the DB.
         queryset = migration.get_queryset(db_alias)
         key_ranges_getter = self._key_ranges_getter(queryset)
-        with get_transaction().atomic(using=db_alias):
+        with get_transaction(db_alias).atomic(using=db_alias):
             attempt_uuid = migration.mark_as_started(db_alias)
             defer_iteration_with_finalize(
                 queryset,

--- a/massmigration/enforcement.py
+++ b/massmigration/enforcement.py
@@ -11,8 +11,8 @@ import logging
 from django.http import HttpResponse
 
 # Djangae Migrations
-from .exceptions import RequiredMigrationNotApplied
-from .loader import is_valid_migration_id
+from .exceptions import DbAliasNotAllowed, RequiredMigrationNotApplied
+from .loader import is_valid_migration_id, store
 from .models import MigrationRecord
 from .utils.test import in_tests
 
@@ -21,37 +21,82 @@ logger = logging.getLogger(__name__)
 APPLIED_MIGRATIONS_CACHE = {}
 
 
-def migration_is_applied(migration_identifier):
+def get_migration_key(migration_id_str_or_tuple):
+    if is_valid_migration_id(migration_id_str_or_tuple):
+        return migration_id_str_or_tuple
+    else:
+        return MigrationRecord.key_from_name_tuple(migration_id_str_or_tuple)
+
+
+def migration_is_applied(migration_identifier, db_alias):
     """ Tells you whether or not the specified migration has been applied to the DB.
         Positive (True) responses are cached to avoid repeated DB queries.
     """
-    if is_valid_migration_id(migration_identifier):
-        key = migration_identifier
-    else:
-        key = MigrationRecord.key_from_name_tuple(migration_identifier)
+    key = (get_migration_key(migration_identifier), db_alias)
     try:
         return APPLIED_MIGRATIONS_CACHE[key]
     except KeyError:
-        applied = MigrationRecord.objects.filter(key=key, is_applied=True).exists()
+        applied = MigrationRecord.objects.using(db_alias).filter(key=key, is_applied=True).exists()
         if applied:
             APPLIED_MIGRATIONS_CACHE[key] = True
             return True
     return False
 
 
-def requires_migration(migration_identifier, skip_in_tests=True):
+def requires_migration(migration_identifier, db_alias=[], is_view=False, skip_in_tests=True):
     """ Function decorator which prevents the function being run if the specified migration is not
         applied.
     """
+    def enforce_migration():
+        key = get_migration_key(migration_identifier)
+
+        migration = store.by_key(key)
+        if not migration:
+            raise ValueError(f"Migration with key '{key}' not found.")
+
+        allowed_db_aliases = migration.get_allowed_db_aliases()
+
+        # By default if db_alias is not specified, we assume the migration needs to be applied on all the allowed_db_aliases
+        # specified in the migration
+        if not db_alias:
+            required_migrations_db_aliases = allowed_db_aliases
+        else:
+            if db_alias not in allowed_db_aliases:
+                raise DbAliasNotAllowed(
+                    f"Requires_migration improperly configured. "
+                    f"Configured to require migration <{migration_identifier}> on DB <{db_alias}> while the alled DBs are {', '.join(allowed_db_aliases)}."
+                )
+            else:
+                required_migrations_db_aliases = db_alias
+
+        if not (skip_in_tests or in_tests()):
+            if not all([
+                migration_is_applied(migration_identifier, db_alias)
+                for db_alias in required_migrations_db_aliases
+            ]):
+                raise RequiredMigrationNotApplied(
+                    f"Function '{function}'' requires migration {migration_identifier} which has "
+                    "not been applied."
+                )
+
     def decorator(function):
         @wraps(function)
         def replacement(*args, **kwargs):
-            if not (skip_in_tests or in_tests()):
-                if not migration_is_applied(migration_identifier):
-                    raise RequiredMigrationNotApplied(
-                        f"Function '{function}'' requires migration {migration_identifier} which has "
-                        "not been applied."
+            if is_view:
+                try:
+                    enforce_migration()
+                except RequiredMigrationNotApplied:
+                    logger.error(
+                        "View function '%s' requires migration '%s' which has not yet been applied.",
+                        function, migration_identifier
                     )
+                    return HttpResponse(
+                        "This resource requires data changes which have not yet been made.",
+                        status=503,
+                    )
+            else:
+                enforce_migration()
+
             return function(*args, **kwargs)
         return replacement
     return decorator
@@ -61,19 +106,4 @@ def view_requires_migration(migration_identifier, skip_in_tests=True):
     """ Same as `requires_migration`, but for view functions. Returns a 503 status HttpResponse
         rather than raising an exception.
     """
-    def decorator(function):
-        @wraps(function)
-        def replacement(*args, **kwargs):
-            if not (skip_in_tests or in_tests()):
-                if not migration_is_applied(migration_identifier):
-                    logger.error(
-                        "View function '%s' requires migration '%s' which has not yet been applied.",
-                        function, migration_identifier
-                    )
-                    return HttpResponse(
-                        "This resource requires data changes which have not yet been made.",
-                        status=503,
-                    )
-            return function(*args, **kwargs)
-        return replacement
-    return decorator
+    return requires_migration(migration_identifier, is_view=True, skip_in_tests=skip_in_tests)

--- a/massmigration/enforcement.py
+++ b/massmigration/enforcement.py
@@ -75,7 +75,7 @@ def requires_migration(migration_identifier, db_aliases=[], is_view=False, skip_
             def enforce_migration():
                 key = get_migration_key(migration_identifier)
 
-                migration = store.by_key.get(key, None)
+                migration = store.by_key[key]
 
                 allowed_db_aliases = migration.get_allowed_db_aliases()
 

--- a/massmigration/enforcement.py
+++ b/massmigration/enforcement.py
@@ -22,66 +22,74 @@ APPLIED_MIGRATIONS_CACHE = {}
 
 
 def get_migration_key(migration_id_str_or_tuple):
-    if is_valid_migration_id(migration_id_str_or_tuple):
-        return migration_id_str_or_tuple
+    if isinstance(migration_id_str_or_tuple, (list, tuple)):
+        key = MigrationRecord.key_from_name_tuple(migration_id_str_or_tuple)
     else:
-        return MigrationRecord.key_from_name_tuple(migration_id_str_or_tuple)
+        key = migration_id_str_or_tuple
+
+    if store.by_key.get(key, None) is None:
+        raise ValueError(
+            f"Provided migration with key '{key}' not found."
+            f"Available keys are {', '.join(store.by_key.keys())}"
+        )
+
+    return key
 
 
 def migration_is_applied(migration_identifier, db_alias):
     """ Tells you whether or not the specified migration has been applied to the DB.
         Positive (True) responses are cached to avoid repeated DB queries.
     """
-    key = (get_migration_key(migration_identifier), db_alias)
+    migration_key = get_migration_key(migration_identifier)
+    cache_key = (get_migration_key(migration_identifier), db_alias)
     try:
-        return APPLIED_MIGRATIONS_CACHE[key]
+        return APPLIED_MIGRATIONS_CACHE[cache_key]
     except KeyError:
-        applied = MigrationRecord.objects.using(db_alias).filter(key=key, is_applied=True).exists()
+        applied = MigrationRecord.objects.using(db_alias).filter(key=migration_key, is_applied=True).exists()
         if applied:
-            APPLIED_MIGRATIONS_CACHE[key] = True
+            APPLIED_MIGRATIONS_CACHE[cache_key] = True
             return True
     return False
 
 
-def requires_migration(migration_identifier, db_alias=[], is_view=False, skip_in_tests=True):
+def requires_migration(migration_identifier, db_aliases=[], is_view=False, skip_in_tests=True):
     """ Function decorator which prevents the function being run if the specified migration is not
         applied.
     """
-    def enforce_migration():
-        key = get_migration_key(migration_identifier)
-
-        migration = store.by_key(key)
-        if not migration:
-            raise ValueError(f"Migration with key '{key}' not found.")
-
-        allowed_db_aliases = migration.get_allowed_db_aliases()
-
-        # By default if db_alias is not specified, we assume the migration needs to be applied on all the allowed_db_aliases
-        # specified in the migration
-        if not db_alias:
-            required_migrations_db_aliases = allowed_db_aliases
-        else:
-            if db_alias not in allowed_db_aliases:
-                raise DbAliasNotAllowed(
-                    f"Requires_migration improperly configured. "
-                    f"Configured to require migration <{migration_identifier}> on DB <{db_alias}> while the alled DBs are {', '.join(allowed_db_aliases)}."
-                )
-            else:
-                required_migrations_db_aliases = db_alias
-
-        if not (skip_in_tests or in_tests()):
-            if not all([
-                migration_is_applied(migration_identifier, db_alias)
-                for db_alias in required_migrations_db_aliases
-            ]):
-                raise RequiredMigrationNotApplied(
-                    f"Function '{function}'' requires migration {migration_identifier} which has "
-                    "not been applied."
-                )
 
     def decorator(function):
         @wraps(function)
         def replacement(*args, **kwargs):
+            def enforce_migration():
+                key = get_migration_key(migration_identifier)
+
+                migration = store.by_key.get(key, None)
+                if not migration:
+                    raise ValueError(f"Migration with key '{key}' not found.")
+
+                allowed_db_aliases = migration.get_allowed_db_aliases()
+
+                # By default if db_alias is not specified, we assume the migration needs to be applied on all the allowed_db_aliases
+                # specified in the migration
+                if not db_aliases:
+                    required_migrations_db_aliases = allowed_db_aliases
+                else:
+                    if any([db_alias not in allowed_db_aliases for db_alias in db_aliases]):
+                        raise DbAliasNotAllowed(
+                            f"requires_migration decorator improperly configured. "
+                            f"It requires the migration <{migration_identifier}> to have run on <{', '.join(db_aliases)}> "
+                            f"while the allowes databases are <{', '.join(allowed_db_aliases)}>."
+                        )
+                    else:
+                        required_migrations_db_aliases = db_aliases
+
+                if not (skip_in_tests and in_tests()):
+                    if not all([migration_is_applied(migration_identifier, db_alias) for db_alias in required_migrations_db_aliases]):
+                        raise RequiredMigrationNotApplied(
+                            f"Migration '{function}'' requires migration {migration_identifier} which has "
+                            "not been applied."
+                        )
+
             if is_view:
                 try:
                     enforce_migration()
@@ -102,8 +110,8 @@ def requires_migration(migration_identifier, db_alias=[], is_view=False, skip_in
     return decorator
 
 
-def view_requires_migration(migration_identifier, skip_in_tests=True):
+def view_requires_migration(migration_identifier, db_aliases=[], skip_in_tests=True):
     """ Same as `requires_migration`, but for view functions. Returns a 503 status HttpResponse
         rather than raising an exception.
     """
-    return requires_migration(migration_identifier, is_view=True, skip_in_tests=skip_in_tests)
+    return requires_migration(migration_identifier, is_view=True, db_aliases=db_aliases, skip_in_tests=skip_in_tests)

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -24,3 +24,9 @@ class CannotRunOnDB(Exception):
     """ Error for when a migration can't be run on a specified connection.
     """
     pass
+
+
+class DbAliasNotAllowed(Exception):
+    """ Error for when a migration can't be run on a specified connection.
+    """
+    pass

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -1,4 +1,4 @@
-from django.db import ConnectionDoesNotExist
+from django.db.utils import ConnectionDoesNotExist
 
 
 class MigrationError(Exception):

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -26,6 +26,7 @@ class CannotRunOnDB(Exception):
     pass
 
 
+# TODO: replace ConnectionDoesNotExists
 class DbAliasNotAllowed(Exception):
     """ Error for when an invalid db_alias is provided.
     """

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -27,6 +27,6 @@ class CannotRunOnDB(Exception):
 
 
 class DbAliasNotAllowed(Exception):
-    """ Error for when a migration can't be run on a specified connection.
+    """ Error for when an invalid db_alias is provided.
     """
     pass

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -1,3 +1,6 @@
+from django.db import ConnectionDoesNotExist
+
+
 class MigrationError(Exception):
     """ Base exception class for migration related errors. """
 
@@ -26,8 +29,7 @@ class CannotRunOnDB(Exception):
     pass
 
 
-# TODO: replace ConnectionDoesNotExists
-class DbAliasNotAllowed(Exception):
+class DbAliasNotAllowed(ConnectionDoesNotExist):
     """ Error for when an invalid db_alias is provided.
     """
     pass

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -18,3 +18,9 @@ class RequiredMigrationNotApplied(Exception):
         tried to run when that migration is not yet applied.
     """
     pass
+
+
+class CannotRunOnDB(Exception):
+    """ Error for when a migration can't be run on a specified connection.
+    """
+    pass

--- a/massmigration/loader.py
+++ b/massmigration/loader.py
@@ -52,6 +52,7 @@ store = MigrationsStore()
 def is_valid_migration_name(name):
     return bool(re.match(r"^[a-z0-9_]+$", name))
 
+
 def is_valid_migration_id(name):
     return bool(re.match(r"^\d{1,5}_[a-z0-9_]+$", name))
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -112,7 +112,7 @@ class BaseMigration:
 
     def mark_as_started(self, db_alias) -> UUID:
         """ Mark the migration as started in the database. Return the attempt UUID. """
-        with get_transaction().atomic(using=db_alias):
+        with get_transaction(db_alias).atomic(using=db_alias):
             if not self.can_be_started(db_alias):
                 raise MigrationAlreadyStarted(
                     f"Migration {self.__class__.__name__} has already been initiated."
@@ -132,7 +132,7 @@ class BaseMigration:
     @retry_on_error()
     def mark_as_finished(self, db_alias):
         """ Mark the migration as applied/finalized in the database. """
-        with get_transaction().atomic(using=db_alias):
+        with get_transaction(db_alias).atomic(using=db_alias):
             migration = MigrationRecord.objects.using(db_alias).get(key=self.key)
             if migration.is_applied:
                 logger.warning("Migration %s is already marked as applied.", self.key)

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -97,7 +97,7 @@ class BaseMigration:
         allowed_db_aliases = self.get_allowed_db_aliases()
         if db_alias not in allowed_db_aliases:
             raise CannotRunOnDB(
-                f"Migration {self.key} can't run on {self.database_alias}. "
+                f"Migration {self.key} can't run on {db_alias}. "
                 f"The allowed DBs for this migration are {', '.join(allowed_db_aliases)}. "
             )
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -154,6 +154,9 @@ class BaseMigration:
                     "yet been applied."
                 )
 
+    def get_migration_record(self, db_alias):
+        return MigrationRecord.objects.using(db_alias).filter(key=self.key).first()
+
 
 class SimpleMigration(BaseMigration):
     """ A migration which only needs to apply a very quick and simple change to the database which

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -190,7 +190,7 @@ class MapperMigration(BaseMigration):
         """ Returns the Django queryset which is to be mapped over. """
         raise NotImplementedError("The `get_queryset` method must be implemented by subclasses.")
 
-    def operation(self, obj: models.Model) -> None:
+    def operation(self, obj: models.Model, db_alias: str) -> None:
         """ This is what will get called on each model instance in the queryset. """
         raise NotImplementedError("The `operation` method must be implemented by subclasses.")
 
@@ -224,7 +224,7 @@ class MapperMigration(BaseMigration):
                 obj.pk,
             )
             try:
-                self.operation(obj)
+                self.operation(obj, db_alias)
             except Exception as error:
                 logger.exception(
                     "Error in migration %s trying to process object %s (pk=%r).",

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_all_db_aliases():
-    # We append None here to allow the migration to run without specifying a using and therefore
-    # allowing django/django router to do its course.
-    return list(settings.DATABASES.keys()) + [None]
+    return list(settings.DATABASES.keys())
 
 
 def _is_valid_db_alias(db_alias):

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -54,7 +54,7 @@ class BaseMigration:
             any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_db_aliases])
         ):
             raise DbAliasNotAllowed(
-                    f"Provided Migration <allowed_database_alias> for {self.key} Migration are invalid."
+                    f"Migration {self.key} provided invalid value(s) in `allowed_database_aliases`. "
                     f"Got <{cls.allowed_db_aliases}> while the available dbs are {', '.join(all_db_aliases)}. "
                 )
 
@@ -98,7 +98,7 @@ class BaseMigration:
         if db_alias not in allowed_db_aliases:
             raise CannotRunOnDB(
                 f"Migration {self.key} can't run on {self.database_alias}. "
-                f"The available dbs are {', '.join(allowed_db_aliases)}. "
+                f"The allowed DBs for this migration are {', '.join(allowed_db_aliases)}. "
             )
 
         self.check_dependencies(db_alias)

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -50,18 +50,18 @@ class BaseMigration:
 
         if (
             cls.allowed_database_aliases is not None and  ## If not set, then all dbs are allowed
-            any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_database_alias])
+            any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_database_aliases])
         ):
             raise DbAliasNotAllowed(
                     f"Provided Migration <allowed_database_alias> for {self.key} Migration are invalid."
-                    f"Got {cls.allowed_database_alias} while the available dbs are {', '.join(all_db_aliases)}. "
+                    f"Got {cls.allowed_database_aliases} while the available dbs are {', '.join(all_db_aliases)}. "
                 )
 
     @classmethod
     def get_allowed_database_aliases(cls):
         if cls.allowed_database_aliases is None:
             return get_all_db_aliases()
-        return cls.allowed_database_alias
+        return cls.allowed_database_aliases
 
     def __init__(self, app_label, name):
         self.app_label = app_label

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -31,7 +31,7 @@ class BaseMigration:
     """ An operation to be performed on the database. """
 
     # TODO validate this are availabe in settings.DATABASES
-    allowed_database_aliases = None
+    allowed_db_aliases = None
 
     dependencies = []  # A list of (app_label, migration_name) pairs
 
@@ -49,19 +49,19 @@ class BaseMigration:
         all_db_aliases = get_all_db_aliases()
 
         if (
-            cls.allowed_database_aliases is not None and  ## If not set, then all dbs are allowed
-            any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_database_aliases])
+            cls.allowed_db_aliases is not None and  ## If not set, then all dbs are allowed
+            any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_db_aliases])
         ):
             raise DbAliasNotAllowed(
                     f"Provided Migration <allowed_database_alias> for {self.key} Migration are invalid."
-                    f"Got {cls.allowed_database_aliases} while the available dbs are {', '.join(all_db_aliases)}. "
+                    f"Got {cls.allowed_db_aliases} while the available dbs are {', '.join(all_db_aliases)}. "
                 )
 
     @classmethod
-    def get_allowed_database_aliases(cls):
-        if cls.allowed_database_aliases is None:
+    def get_allowed_db_aliases(cls):
+        if cls.allowed_db_aliases is None:
             return get_all_db_aliases()
-        return cls.allowed_database_aliases
+        return cls.allowed_db_aliases
 
     def __init__(self, app_label, name):
         self.app_label = app_label
@@ -93,10 +93,10 @@ class BaseMigration:
         """ Pass the migration to the backend to perform the data operation(s).
             This is what should be called by the web interface to trigger the migration.
         """
-        if db_alias not in self.get_allowed_database_aliases():
+        if db_alias not in self.get_allowed_db_aliases():
             raise CannotRunOnDB(
                 f"Migration {self.key} can't run on {self.database_alias}. "
-                f"The available dbs are {', '.join(self.get_allowed_database_aliases())}. "
+                f"The available dbs are {', '.join(self.get_allowed_db_aliases())}. "
             )
 
         self.check_dependencies(db_alias)

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -11,7 +11,7 @@ from django.utils.module_loading import import_string
 # Mass Migration
 from . import record_cache
 from .constants import DEFAULT_BACKEND
-from .exceptions import CannotRunOnDB, DependentMigrationNotApplied, MigrationAlreadyStarted
+from .exceptions import CannotRunOnDB, DbAliasNotAllowed, DependentMigrationNotApplied, MigrationAlreadyStarted
 from .models import MigrationRecord
 from .utils.transaction import get_transaction
 
@@ -30,6 +30,9 @@ def _is_valid_db_alias(db_alias):
 class BaseMigration:
     """ An operation to be performed on the database. """
 
+    # TODO validate this are availabe in settings.DATABASES
+    allowed_database_aliases = None
+
     dependencies = []  # A list of (app_label, migration_name) pairs
 
     # This can be set to make a migration run on a specific backend, rather than the one that's
@@ -40,6 +43,25 @@ class BaseMigration:
     # migration. Custom migration types can be run on custom backends which support them by using
     # this attribute.
     backend_method: str = None
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        all_db_aliases = get_all_db_aliases()
+
+        if (
+            cls.allowed_database_aliases is not None and  ## If not set, then all dbs are allowed
+            any([allowed_db not in all_db_aliases for allowed_db in cls.allowed_database_alias])
+        ):
+            raise DbAliasNotAllowed(
+                    f"Provided Migration <allowed_database_alias> for {self.key} Migration are invalid."
+                    f"Got {cls.allowed_database_alias} while the available dbs are {', '.join(all_db_aliases)}. "
+                )
+
+    @classmethod
+    def get_allowed_database_aliases(cls):
+        if cls.allowed_database_aliases is None:
+            return get_all_db_aliases()
+        return cls.allowed_database_alias
 
     def __init__(self, app_label, name):
         self.app_label = app_label
@@ -71,10 +93,11 @@ class BaseMigration:
         """ Pass the migration to the backend to perform the data operation(s).
             This is what should be called by the web interface to trigger the migration.
         """
-        if not _is_valid_db_alias(database_alias):
+        if database_alias not in self.get_allowed_database_aliases():
             raise CannotRunOnDB(
                 f"Migration {self.key} can't run on {self.database_alias}. "
-                f"The available dbs are {', '.join(get_all_db_aliases)}. ")
+                f"The available dbs are {', '.join(self.get_allowed_database_aliases())}. "
+            )
 
         self.check_dependencies()
         backend = self.get_backend()

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -174,7 +174,7 @@ class SimpleMigration(BaseMigration):
         logger.info("Running operation for migration %s", self.key)
         self.mark_as_started(db_alias)
         try:
-            self.operation()
+            self.operation(db_alias)
         except Exception as error:
             self.mark_as_errored(db_alias, error)
         else:

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -90,7 +90,7 @@ class BaseMigration:
         backend_class = import_string(self.backend_str)
         return backend_class()
 
-    def launch(self, db_alias=None):
+    def launch(self, db_alias):
         """ Pass the migration to the backend to perform the data operation(s).
             This is what should be called by the web interface to trigger the migration.
         """

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -89,20 +89,20 @@ class BaseMigration:
         backend_class = import_string(self.backend_str)
         return backend_class()
 
-    def launch(self, database_alias=None):
+    def launch(self, db_alias=None):
         """ Pass the migration to the backend to perform the data operation(s).
             This is what should be called by the web interface to trigger the migration.
         """
-        if database_alias not in self.get_allowed_database_aliases():
+        if db_alias not in self.get_allowed_database_aliases():
             raise CannotRunOnDB(
                 f"Migration {self.key} can't run on {self.database_alias}. "
                 f"The available dbs are {', '.join(self.get_allowed_database_aliases())}. "
             )
 
-        self.check_dependencies()
+        self.check_dependencies(db_alias)
         backend = self.get_backend()
         method = getattr(backend, self.backend_method)
-        method(self, database_alias)
+        method(self, db_alias)
         logger.info("Launched migration %s on backend %s", self.key, backend.__class__)
 
     def can_be_started(self, db_alias) -> bool:

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -115,9 +115,8 @@ class BaseMigration:
                 raise MigrationAlreadyStarted(
                     f"Migration {self.__class__.__name__} has already been initiated."
                 )
-            migration = MigrationRecord.objects.create(
+            migration = MigrationRecord.objects.using(db_alias).create(
                 key=self.key,
-                using=db_alias,
             )
             return migration.attempt_uuid
 

--- a/massmigration/models.py
+++ b/massmigration/models.py
@@ -26,7 +26,6 @@ class MigrationRecord(models.Model):
     # I'm still not sure whether the key should be computed from the app_label and name or the
     # other way round. The app_label at least is good for filtering in the Django admin though.
     key = models.CharField(max_length=250, primary_key=True)
-
     app_label = ComputedCharField(
         "_app_label", max_length=100, choices=MemoizedLazyList(get_app_label_choices)
     )
@@ -50,9 +49,6 @@ class MigrationRecord(models.Model):
     has_error = models.BooleanField(default=False)
     last_error = models.TextField(blank=True)
     was_faked = models.BooleanField(default=False)
-
-    class Meta:
-        unique_together = ("app_label", "name")
 
     def _app_label(self):
         return self.key.split(":")[0]

--- a/massmigration/models.py
+++ b/massmigration/models.py
@@ -13,7 +13,9 @@ from .utils.functional import MemoizedLazyList
 
 
 class MigrationRecord(models.Model):
-    """ Stores a record of a particular migration being applied to the database. """
+    """ Stores a record of a particular migration being applied to the database.
+    The assumption is these models are stored on the same DB the migration has been applied to.
+    """
 
     class Status(models.TextField):
         APPLIED = "APPLIED"
@@ -24,6 +26,7 @@ class MigrationRecord(models.Model):
     # I'm still not sure whether the key should be computed from the app_label and name or the
     # other way round. The app_label at least is good for filtering in the Django admin though.
     key = models.CharField(max_length=250, primary_key=True)
+
     app_label = ComputedCharField(
         "_app_label", max_length=100, choices=MemoizedLazyList(get_app_label_choices)
     )
@@ -47,6 +50,9 @@ class MigrationRecord(models.Model):
     has_error = models.BooleanField(default=False)
     last_error = models.TextField(blank=True)
     was_faked = models.BooleanField(default=False)
+
+    class Meta:
+        unique_together = ("app_label", "name")
 
     def _app_label(self):
         return self.key.split(":")[0]

--- a/massmigration/record_cache.py
+++ b/massmigration/record_cache.py
@@ -38,7 +38,7 @@ def record_post_save(sender, **kwargs):
         marked as started, marked as errored or marked as finished).
     """
     record = kwargs["instance"]
-    cache_key = get_cache_key(record.key)
+    cache_key = get_cache_key(record.key, record._state.db)
     cache.set(cache_key, record, cache_timeout())
 
 

--- a/massmigration/record_cache.py
+++ b/massmigration/record_cache.py
@@ -12,12 +12,12 @@ from massmigration.models import MigrationRecord
 DEFAULT_CACHE_TIMEOUT = 60
 
 
-def get_record(key):
+def get_record(key, db_alias):
     """ Get the MigrationRecord for the given key. This is designed to be called heavily, i.e. for
         every object in a MapperMigration, so the result is cached with a best-effort attempt to
         refresh that cache when the record changes, but with no guarantee of it.
     """
-    cache_key = get_cache_key(key)
+    cache_key = get_cache_key(key, db_alias)
     record = cache.get(cache_key)
     if not record:
         record = MigrationRecord.objects.filter(key=key).first()
@@ -25,8 +25,8 @@ def get_record(key):
     return record
 
 
-def get_cache_key(migration_key):
-    return f"massmigration_record:{migration_key}"
+def get_cache_key(migration_key, db_alias):
+    return f"massmigration_record:{migration_key}:{db_alias}"
 
 
 def cache_timeout():

--- a/massmigration/templates/massmigration/delete_migration.html
+++ b/massmigration/templates/massmigration/delete_migration.html
@@ -5,6 +5,7 @@
 <h1>Cancel/Delete Migration</h1>
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
+<p>Database: {{db_alias}}</p>
 <p class="pt">
 	This will delete the <em>record</em> for the migration in the database.
 </p>

--- a/massmigration/templates/massmigration/delete_migration.html
+++ b/massmigration/templates/massmigration/delete_migration.html
@@ -5,7 +5,6 @@
 <h1>Cancel/Delete Migration</h1>
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
-<p>Database: {{db_alias|default:'autoselect_db'}}</p>
 <p class="pt">
 	This will delete the <em>record</em> for the migration in the database.
 </p>

--- a/massmigration/templates/massmigration/delete_migration.html
+++ b/massmigration/templates/massmigration/delete_migration.html
@@ -5,6 +5,7 @@
 <h1>Cancel/Delete Migration</h1>
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
+<p>Database: {{db_alias|default:'autoselect_db'}}</p>
 <p class="pt">
 	This will delete the <em>record</em> for the migration in the database.
 </p>

--- a/massmigration/templates/massmigration/delete_migration.html
+++ b/massmigration/templates/massmigration/delete_migration.html
@@ -7,7 +7,7 @@
 <p>{{migration.description}}</p>
 <p>Database: {{db_alias}}</p>
 <p class="pt">
-	This will delete the <em>record</em> for the migration in the database.
+	This will delete the <em>record</em> for the migration in the '{{db_alias}}' database.
 </p>
 <p>
 	Once you have deleted the record, you will be able to run the migration again.

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -6,8 +6,11 @@
 <table class="table">
 	<thead>
 		<tr>
-			<th>App</th>
-			<th>Migration</th>
+			<th rowspan="2">App</th>
+			<th rowspan="2">Migration</th>
+			<th colspan="{{available_db_aliases|length}}">Database</th>
+		</tr>
+		<tr>
 			{% for db_alias in available_db_aliases %}
 				<th>{{db_alias}}</th>
 			{% endfor %}

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -8,8 +8,8 @@
 		<tr>
 			<th>App</th>
 			<th>Migration</th>
-			{% for db in available_db_aliases %}
-				<th>{{db|default:"autoselect_db"}}</th>
+			{% for db_alias in available_db_aliases %}
+				<th>{{db_alias}}</th>
 			{% endfor %}
 		</tr>
 	</thead>

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -17,21 +17,24 @@
 		{% for migration in migrations %}
 			<tr>
 				<td>{{migration.app_label}}</td>
-				<td><a>{{migration.name}}</a></td>
-				{% for db_alias, migration_record in migration.records_map.items %}
-				<td>
-					<div>
-						<a href="{% url 'massmigration_detail' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Details</a>
-					</div>
-					<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
-					<div>
-						{% if not migration_record %}
-							<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
+				<td><a href="{% url 'massmigration_detail' key=migration.key%}{% if db_alias %}">{{migration.name}}</a></td>
+				{% for db_alias in available_db_aliases %}
+					{% with migration_record=migrations.records_map[db_alias] %}
+						{if migration_record %}
+							<td>
+								<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
+								<div>
+									{% if not migration_record %}
+										<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
+									{% else %}
+										<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
+									{% endif %}
+								</div>
+							</td>
 						{% else %}
-							<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
+							<td>Not allowed on DB</td>
 						{% endif %}
-					</div>
-				</td>
+
 				{% endfor %}
 			</tr>
 		{% endfor %}

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -23,14 +23,14 @@
 					 	{% with migration_record=migration_for_alias.record %}
 						<td>
 							<div>
-								<a href="{% url 'massmigration_detail' key=migration.key %}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Detail</a>
+								<a href="{% url 'massmigration_detail' key=migration.key db_alias=db_alias%}">Detail</a>
 							</div>
 							<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
 							<div>
 								{% if not migration_record %}
-									<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
+									<a href="{% url 'massmigration_run' key=migration.key db_alias=db_alias %}">Run...</a>
 								{% else %}
-									<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Delete...</a>
+									<a href="{% url 'massmigration_delete' key=migration.key db_alias=db_alias %}">Delete...</a>
 								{% endif %}
 							</div>
 						</td>

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -23,7 +23,7 @@
 					 	{% with migration_record=migration_for_alias.record %}
 						<td>
 							<div>
-								<a href="{% url 'massmigration_detail' key=migration.key %}?db_alias={{db_alias}}{% endif %}">Detail</a>
+								<a href="{% url 'massmigration_detail' key=migration.key %}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Detail</a>
 							</div>
 							<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
 							<div>

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -18,22 +18,21 @@
 			<tr>
 				<td>{{migration.app_label}}</td>
 				<td><a href="{% url 'massmigration_detail' key=migration.key%}{% if db_alias %}">{{migration.name}}</a></td>
-				{% for db_alias in available_db_aliases %}
-					{% with migration_record=migrations.records_map[db_alias] %}
-						{if migration_record %}
-							<td>
-								<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
-								<div>
-									{% if not migration_record %}
-										<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
-									{% else %}
-										<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
-									{% endif %}
-								</div>
-							</td>
-						{% else %}
-							<td>Not allowed on DB</td>
-						{% endif %}
+				{% for db_alias, migration_record in records_map %}
+					{if migration_record %}
+						<td>
+							<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
+							<div>
+								{% if not migration_record %}
+									<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
+								{% else %}
+									<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
+								{% endif %}
+							</div>
+						</td>
+					{% else %}
+						<td>Not allowed on DB</td>
+					{% endif %}
 
 				{% endfor %}
 			</tr>

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -17,19 +17,24 @@
 		{% for migration in migrations %}
 			<tr>
 				<td>{{migration.app_label}}</td>
-				<td><a href="{% url 'massmigration_detail' key=migration.key%}{% if db_alias %}">{{migration.name}}</a></td>
-				{% for db_alias, migration_record in records_map %}
-					{if migration_record %}
+				<td>{{migration.name}}</td>
+				{% for db_alias, migration_for_alias in migration.records_map.items %}
+					{% if migration_for_alias.is_allowed_on_db_alias %}
+					 	{% with migration_record=migration_for_alias.record %}
 						<td>
+							<div>
+								<a href="{% url 'massmigration_detail' key=migration.key %}?db_alias={{db_alias}}{% endif %}">Detail</a>
+							</div>
 							<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
 							<div>
 								{% if not migration_record %}
 									<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
 								{% else %}
-									<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
+									<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Delete...</a>
 								{% endif %}
 							</div>
 						</td>
+						{% endwith %}
 					{% else %}
 						<td>Not allowed on DB</td>
 					{% endif %}

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -8,23 +8,33 @@
 		<tr>
 			<th>App</th>
 			<th>Migration</th>
-			<th>Status</th>
-			<th>Actions</th>
+			{% for db in available_db_aliases %}
+				<th>{{db|default:"autoselect_db"}}</th>
+			{% endfor %}
 		</tr>
 	</thead>
 	<tbody>
-	{% for migration in migrations %}
-		<tr>
-			<td>{{migration.app_label}}</td>
-			<td><a href="{% url 'massmigration_detail' key=migration.key %}">{{migration.name}}</a></td>
-			<td>{% if migration.record %}{{migration.record.status}}{% else %}NOT RUN{% endif %}</td>
-			<td>
-				{% if not migration.record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>
-				{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}">Delete...</a>
-				{% endif %}
-			</td>
-		</tr>
-	{% endfor %}
+		{% for migration in migrations %}
+			<tr>
+				<td>{{migration.app_label}}</td>
+				<td><a>{{migration.name}}</a></td>
+				{% for db_alias, migration_record in migration.records_map.items %}
+				<td>
+					<div>
+						<a href="{% url 'massmigration_detail' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Details</a>
+					</div>
+					<div>{% if migration_record %}{{migration_record.status}}{% else %}NOT RUN{% endif %}</div>
+					<div>
+						{% if not migration_record %}
+							<a href="{% url 'massmigration_run' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}}{% endif %}">Run...</a>
+						{% else %}
+							<a href="{% url 'massmigration_delete' key=migration.key%}{% if db_alias %}?db_alias={{db_alias}{% endif %}">Delete...</a>
+						{% endif %}
+					</div>
+				</td>
+				{% endfor %}
+			</tr>
+		{% endfor %}
 	</tbody>
 </table>
 

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -12,11 +12,15 @@
 		<td>{{migration.backend_str}}</td>
 	</tr>
 	<tr scope="row">
+		<th>Database</th>
+		<td>{{db_alias|default:"autoselect_db"}}</td>
+	</tr>
+	<tr scope="row">
 		<th>Dependencies</th>
 		<td>
 			{% for dependency in dependencies %}
 				<div>
-					<a href="{% url 'massmigration_detail' key=dependency.key %}">{{dependency.key}}</a>
+					<a href="{% url 'massmigration_detail' key=dependency.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">{{dependency.key}}</a>
 					({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
 				</div>
 			{% empty %}
@@ -51,8 +55,8 @@
 </table>
 <h2>Actions</h2>
 <p>
-	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>
-	{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}">Cancel/Delete...</a>
+	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">Run...</a>
+	{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">Cancel/Delete...</a>
 	{% endif %}
 </p>
 

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -13,7 +13,7 @@
 	</tr>
 	<tr scope="row">
 		<th>Database</th>
-		<td>{{db_alias|default:"autoselect_db"}}</td>
+		<td>{{db_alias}}</td>
 	</tr>
 	<tr scope="row">
 		<th>Dependencies</th>

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -20,7 +20,7 @@
 		<td>
 			{% for dependency in dependencies %}
 				<div>
-					<a href="{% url 'massmigration_detail' key=dependency.key db_alias=db_alias%}">{{dependency.key}}</a>
+					<a href="{% url 'massmigration_detail' key=dependency.key db_alias=db_alias %}">{{dependency.key}}</a>
 					({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
 				</div>
 			{% empty %}

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -20,7 +20,7 @@
 		<td>
 			{% for dependency in dependencies %}
 				<div>
-					<a href="{% url 'massmigration_detail' key=dependency.key %}">{{dependency.key}}</a>
+					<a href="{% url 'massmigration_detail' key=dependency.key db_alias=db_alias%}">{{dependency.key}}</a>
 					({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
 				</div>
 			{% empty %}
@@ -55,8 +55,8 @@
 </table>
 <h2>Actions</h2>
 <p>
-	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>
-	{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}">Cancel/Delete...</a>
+	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key db_alias=db_alias %}">Run...</a>
+	{% else %}<a href="{% url 'massmigration_delete' key=migration.key db_alias=db_alias %}">Cancel/Delete...</a>
 	{% endif %}
 </p>
 

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -5,54 +5,58 @@
 <h1>Migration <code>{{migration.key}}</h1>
 <p>{{migration.description}}</p>
 
-<table class="table mt">
+{% for db_alias, record in migration.records_map.items %}
 
-	<tr scope="row">
-		<th>Backend</th>
-		<td>{{migration.backend_str}}</td>
-	</tr>
-	<tr scope="row">
-		<th>Database</th>
-		<td>{{db_alias}}</td>
-	</tr>
-	<tr scope="row">
-		<th>Dependencies</th>
-		<td>
-			{% for dependency in dependencies %}
-				<div>
-					<a href="{% url 'massmigration_detail' key=dependency.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">{{dependency.key}}</a>
-					({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
-				</div>
-			{% empty %}
-				None
-			{% endfor %}
-		</td>
-	</tr>
-	<tr scope="row">
-		<th>Status</th>
-		<td>{% if record %}{{record.status}}{% else %}NOT RUN{% endif %}</td>
-	</tr>
-	<tr scope="row">
-		<th>Started at</th>
-		<td>{{record.initiated_at|default:'-'}}</td>
-	</tr>
-	<tr scope="row">
-		<th>Finished at</th>
-		<td>{{record.applied_at|default:'-'}}</td>
-	</tr>
-	<tr scope="row">
-		<th>Was faked</th>
-		<td>{% if record.applied_at %}{{record.was_faked|yesno}}{% else %}-{% endif %}</td>
-	</tr>
-	<tr scope="row">
-		<th>Has error</th>
-		<td>{{record.has_error|yesno}}</td>
-	</tr>
-	<tr scope="row">
-		<th>Last error</th>
-		<td><code>{{record.last_error|default:'-'}}</code></td>
-	</tr>
-</table>
+	<h2>Database: {{db_alias}}</h2>
+
+	<table class="table mt">
+
+		<tr scope="row">
+			<th>Backend</th>
+			<td>{{migration.backend_str}}</td>
+		</tr>
+		<tr scope="row">
+			<th>Database</th>
+			<td>{{db_alias}}</td>
+		</tr>
+		<tr scope="row">
+			<th>Dependencies</th>
+			<td>
+				{% for dependency in dependencies_by_db_alias[db_alias] %}
+					<div>
+						<a href="{% url 'massmigration_detail' key=dependency.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">{{dependency.key}}</a>
+						({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
+					</div>
+				{% empty %}
+					None
+				{% endfor %}
+			</td>
+		</tr>
+		<tr scope="row">
+			<th>Status</th>
+			<td>{% if record %}{{record.status}}{% else %}NOT RUN{% endif %}</td>
+		</tr>
+		<tr scope="row">
+			<th>Started at</th>
+			<td>{{record.initiated_at|default:'-'}}</td>
+		</tr>
+		<tr scope="row">
+			<th>Finished at</th>
+			<td>{{record.applied_at|default:'-'}}</td>
+		</tr>
+		<tr scope="row">
+			<th>Was faked</th>
+			<td>{% if record.applied_at %}{{record.was_faked|yesno}}{% else %}-{% endif %}</td>
+		</tr>
+		<tr scope="row">
+			<th>Has error</th>
+			<td>{{record.has_error|yesno}}</td>
+		</tr>
+		<tr scope="row">
+			<th>Last error</th>
+			<td><code>{{record.last_error|default:'-'}}</code></td>
+		</tr>
+	</table>
 <h2>Actions</h2>
 <p>
 	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">Run...</a>

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -5,62 +5,58 @@
 <h1>Migration <code>{{migration.key}}</h1>
 <p>{{migration.description}}</p>
 
-{% for db_alias, record in migration.records_map.items %}
+<table class="table mt">
 
-	<h2>Database: {{db_alias}}</h2>
-
-	<table class="table mt">
-
-		<tr scope="row">
-			<th>Backend</th>
-			<td>{{migration.backend_str}}</td>
-		</tr>
-		<tr scope="row">
-			<th>Database</th>
-			<td>{{db_alias}}</td>
-		</tr>
-		<tr scope="row">
-			<th>Dependencies</th>
-			<td>
-				{% for dependency in dependencies_by_db_alias[db_alias] %}
-					<div>
-						<a href="{% url 'massmigration_detail' key=dependency.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">{{dependency.key}}</a>
-						({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
-					</div>
-				{% empty %}
-					None
-				{% endfor %}
-			</td>
-		</tr>
-		<tr scope="row">
-			<th>Status</th>
-			<td>{% if record %}{{record.status}}{% else %}NOT RUN{% endif %}</td>
-		</tr>
-		<tr scope="row">
-			<th>Started at</th>
-			<td>{{record.initiated_at|default:'-'}}</td>
-		</tr>
-		<tr scope="row">
-			<th>Finished at</th>
-			<td>{{record.applied_at|default:'-'}}</td>
-		</tr>
-		<tr scope="row">
-			<th>Was faked</th>
-			<td>{% if record.applied_at %}{{record.was_faked|yesno}}{% else %}-{% endif %}</td>
-		</tr>
-		<tr scope="row">
-			<th>Has error</th>
-			<td>{{record.has_error|yesno}}</td>
-		</tr>
-		<tr scope="row">
-			<th>Last error</th>
-			<td><code>{{record.last_error|default:'-'}}</code></td>
-		</tr>
-	</table>
+	<tr scope="row">
+		<th>Backend</th>
+		<td>{{migration.backend_str}}</td>
+	</tr>
+	<tr scope="row">
+		<th>Database</th>
+		<td>{{db_alias}}</td>
+	</tr>
+	<tr scope="row">
+		<th>Dependencies</th>
+		<td>
+			{% for dependency in dependencies %}
+				<div>
+					<a href="{% url 'massmigration_detail' key=dependency.key %}">{{dependency.key}}</a>
+					({% if dependency.record %}{{dependency.record.status}}{% else %}NOT RUN{% endif %})
+				</div>
+			{% empty %}
+				None
+			{% endfor %}
+		</td>
+	</tr>
+	<tr scope="row">
+		<th>Status</th>
+		<td>{% if record %}{{record.status}}{% else %}NOT RUN{% endif %}</td>
+	</tr>
+	<tr scope="row">
+		<th>Started at</th>
+		<td>{{record.initiated_at|default:'-'}}</td>
+	</tr>
+	<tr scope="row">
+		<th>Finished at</th>
+		<td>{{record.applied_at|default:'-'}}</td>
+	</tr>
+	<tr scope="row">
+		<th>Was faked</th>
+		<td>{% if record.applied_at %}{{record.was_faked|yesno}}{% else %}-{% endif %}</td>
+	</tr>
+	<tr scope="row">
+		<th>Has error</th>
+		<td>{{record.has_error|yesno}}</td>
+	</tr>
+	<tr scope="row">
+		<th>Last error</th>
+		<td><code>{{record.last_error|default:'-'}}</code></td>
+	</tr>
+</table>
 <h2>Actions</h2>
 <p>
-	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">Run...</a>
-	{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}{% if db_alias%}?db_alias={{db_alias}}{% endif %}">Cancel/Delete...</a>
+	{% if not record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>
+	{% else %}<a href="{% url 'massmigration_delete' key=migration.key %}">Cancel/Delete...</a>
 	{% endif %}
 </p>
 

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias|default:"autoselect_db"}} db</code>.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias}} db</code>.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}}</code>.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias|default:"autoselect_db"}} db</code>.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} </code> on <code>{{migration.database_alias}}</code>db.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}}</code> on <code>{{migration.database_alias}}</code> db.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}}</code> on <code>{{migration.database_alias}}</code> db.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}}</code> on DB <code>{{db_alias}}</code>.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias}} db</code>.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} </code> on <code>{{migration.database_alias}}</code>db.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/migration_templates/custom.py
+++ b/massmigration/templates/migration_templates/custom.py
@@ -11,18 +11,24 @@ class Migration(BaseMigration):
     # For a custom migration, you must set this, and your backend must have this method.
     backend_method: str = NotImplemented
 
+    # This can be set to specify the list of database aliases on which the migration can be applied.
+    # The migration is not forced on a specific DB but rather the `db_alias` for the DB is passed to `launch`
+    # allowing to customise what is retrieved by the migration.
+    # If None the migration can be applied to all databases.
+    allowed_db_aliases: list = None
+
     dependencies = [{% for dependency in dependencies %}
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]
 
-    def launch(self):
-        self.check_dependencies()
-        self.mark_as_started()
+    def launch(self, db_alias):
+        self.check_dependencies(db_alias)
+        self.mark_as_started(db_alias)
 
         # PUT YOUR CODE HERE.
         # It should defer whatever operation(s) you want to perform to a backend which knows how to
         # perform them.
-        # When done, or when an error occurs, the backend must call mark_as_finished() or
-        # mark_as_errored_() on this object as appropriate.
+        # When done, or when an error occurs, the backend must call mark_as_finished(db_alias) or
+        # mark_as_errored_(db_alias) on this object as appropriate.
 
         raise NotImplementedError

--- a/massmigration/templates/migration_templates/mapper.py
+++ b/massmigration/templates/migration_templates/mapper.py
@@ -8,6 +8,13 @@ class Migration(MapperMigration):
     # that's specified in the Django settings
     backend: str = None
 
+    # This can be set to specify the list of database aliases on which the migration can be applied.
+    # The migration is not forced on a specific DB but rather the `db_alias` for the DB is passed to `get_queryset`
+    # allowing to customise what is retrieved by the migration.
+    # If None the migration can be applied to all databases.
+    allowed_db_aliases: list = None
+
+
     dependencies = [{% for dependency in dependencies %}
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]

--- a/massmigration/templates/migration_templates/mapper.py
+++ b/massmigration/templates/migration_templates/mapper.py
@@ -12,7 +12,7 @@ class Migration(MapperMigration):
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]
 
-    def get_queryset(self):
+    def get_queryset(self, db_alias):
 
         # PUT YOUR CODE HERE.
         # It must return a queryset for the objects which you wish to perform the operation on.

--- a/massmigration/templates/migration_templates/simple.py
+++ b/massmigration/templates/migration_templates/simple.py
@@ -8,6 +8,12 @@ class Migration(SimpleMigration):
     # that's specified in the Django settings
     backend: str = None
 
+    # This can be set to specify the list of database aliases on which the migration can be applied.
+    # The migration is not forced on a specific DB but rather the `db_alias` for the DB is passed to `operation`
+    # allowing to customise what is retrieved by the migration.
+    # If None the migration can be applied to all databases.
+    allowed_db_aliases: list = None
+
     dependencies = [
         ('app_name', '001_move_something'),
     ]

--- a/massmigration/templates/migration_templates/simple.py
+++ b/massmigration/templates/migration_templates/simple.py
@@ -16,7 +16,7 @@ class Migration(SimpleMigration):
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]
 
-    def operation(self):
+    def operation(self, db_alias):
 
         # PUT YOUR CODE HERE.
         # It should perform the entire migration operation in this single step.

--- a/massmigration/templates/migration_templates/simple.py
+++ b/massmigration/templates/migration_templates/simple.py
@@ -8,6 +8,10 @@ class Migration(SimpleMigration):
     # that's specified in the Django settings
     backend: str = None
 
+    dependencies = [
+        ('app_name', '001_move_something'),
+    ]
+
     dependencies = [{% for dependency in dependencies %}
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]

--- a/massmigration/templates/migration_templates/simple.py
+++ b/massmigration/templates/migration_templates/simple.py
@@ -14,10 +14,6 @@ class Migration(SimpleMigration):
     # If None the migration can be applied to all databases.
     allowed_db_aliases: list = None
 
-    dependencies = [
-        ('app_name', '001_move_something'),
-    ]
-
     dependencies = [{% for dependency in dependencies %}
         ("{{dependency.0}}", "{{dependency.1}}"),{% endfor %}
     ]

--- a/massmigration/urls.py
+++ b/massmigration/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 urlpatterns = [
     path("manage/", views.manage_migrations, name="massmigration_manage"),
-    path("run/<str:key>/<str:db_alias>", views.run_migration, name="massmigration_run"),
-    path("detail/<str:key>/<str:db_alias>", views.migration_detail, name="massmigration_detail"),
-    path("delete/<str:key>/<str:db_alias>", views.delete_migration, name="massmigration_delete"),
+    path("run/<str:key>/<str:db_alias>/", views.run_migration, name="massmigration_run"),
+    path("detail/<str:key>/<str:db_alias>/", views.migration_detail, name="massmigration_detail"),
+    path("delete/<str:key>/<str:db_alias>/", views.delete_migration, name="massmigration_delete"),
 ]

--- a/massmigration/urls.py
+++ b/massmigration/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 urlpatterns = [
     path("manage/", views.manage_migrations, name="massmigration_manage"),
-    path("run/<str:key>/", views.run_migration, name="massmigration_run"),
-    path("detail/<str:key>/", views.migration_detail, name="massmigration_detail"),
-    path("delete/<str:key>/", views.delete_migration, name="massmigration_delete"),
+    path("run/<str:key>/<str:db_alias>", views.run_migration, name="massmigration_run"),
+    path("detail/<str:key>/<str:db_alias>", views.migration_detail, name="massmigration_detail"),
+    path("delete/<str:key>/<str:db_alias>", views.delete_migration, name="massmigration_delete"),
 ]

--- a/massmigration/utils/transaction.py
+++ b/massmigration/utils/transaction.py
@@ -13,9 +13,8 @@ from massmigration.models import MigrationRecord
 # That said, should you be allowed to run the same migration on two different databases?
 
 
-def get_transaction():
-    connection = router.db_for_write(MigrationRecord)
-    engine = settings.DATABASES[connection]["ENGINE"]
+def get_transaction(db_alias):
+    engine = settings.DATABASES[db_alias]["ENGINE"]
     if engine == "gcloudc.db.backends.datastore":
         return datastore_transaction
     return django_transaction

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -30,7 +30,7 @@ def manage_migrations(request):
         for db_alias in available_db_aliases:
             migration.records_map[db_alias] = {
                 "is_allowed_on_db_alias": db_alias in migration.get_allowed_db_aliases(),
-                "record": migration_records_by_db_alias.get(db_alias).get(migration.key, None)
+                "record": migration_records_by_db_alias[db_alias].get(migration.key, None)
             }
 
     context = {

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -66,6 +66,7 @@ def run_migration(request, key, db_alias):
     # else...
     context = {
         "migration": migration,
+        "db_alias": db_alias,
     }
     return render(request, "massmigration/run_migration.html", context)
 

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -50,7 +50,7 @@ def run_migration(request, key, db_alias):
     record = migration.get_migration_record(db_alias)
 
     if record:
-        messages.error(request, f"Migration '{key}' has already been started.")
+        messages.error(request, f"Migration '{key}' for db <{db_alias}> has already been started.")
         return redirect("massmigration_manage")
     try:
         migration.check_dependencies(db_alias)
@@ -76,7 +76,7 @@ def migration_detail(request, key, db_alias):
     # TODO: Show the migrations and their records for any db_alias rather than just the one.
     migration = store.by_key.get(key)
     if not migration:
-        raise Http404(f"Migration with key {key} for db {db_alias} not found.")
+        raise Http404(f"Migration with key {key} not found.")
 
     record = MigrationRecord.objects.using(db_alias).filter(key=key).first()
     dependencies = []
@@ -102,14 +102,14 @@ def delete_migration(request, key, db_alias):
     """ Delete a migration which has already started or has errored. """
     migration = store.by_key.get(key)
     if not migration:
-        raise Http404(f"Migration with key {key} for db {db_alias} not found.")
+        raise Http404(f"Migration with key {key} not found.")
 
     record = migration.get_migration_record(db_alias)
 
     if not record:
         messages.error(
             request,
-            f"Can't delete migration '{key}' because no record for it exists. "
+            f"Can't delete migration '{key}' for db <{db_alias}> because no record for it exists. "
             "Maybe you deleted it already?"
         )
         return redirect("massmigration_manage")

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -74,7 +74,9 @@ def run_migration(request, key, db_alias):
 @superuser_required()
 def migration_detail(request, key, db_alias):
     """ View the details of a single migration. """
-    # TODO: Show the migrations and their records for any db_alias rather than just the one.
+    # TODO(https://github.com/adamalton/django-mass-migration/issues/4):
+    # The migration detail view should collate the state of the Migration
+    # across all allowed_db_aliases.
     migration = store.by_key.get(key)
     if not migration:
         raise Http404(f"Migration with key {key} not found.")

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -20,14 +20,14 @@ def manage_migrations(request):
     # Load the migration records in one query to avoid a separate query for each one
 
     migration_records_by_db_alias = OrderedDict([
-        (db_alias, MigrationRecord.objects.in_bulk().using(db_alias))
+        (db_alias, MigrationRecord.objects.using(db_alias).in_bulk())
         for db_alias in available_db_aliases
     ])
 
     for migration in migrations:
         migration.records_map = OrderedDict([
             (db_alias, migration_records_by_db_alias.get(db_alias, None))
-            for db_alias in migration.get_allowed_database_aliases()
+            for db_alias in available_db_aliases
         ])
 
     context = {

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -41,9 +41,8 @@ def manage_migrations(request):
 
 
 @superuser_required()
-def run_migration(request, key):
+def run_migration(request, key, db_alias):
     """ Trigger the running of a migration. """
-    db_alias = request.GET.get("db_alias", None)
     migration = store.by_key.get(key)
     record = migration.get_migration_record(db_alias)
     if not migration:
@@ -70,10 +69,10 @@ def run_migration(request, key):
 
 
 @superuser_required()
-def migration_detail(request, key):
+def migration_detail(request, key, db_alias):
     """ View the details of a single migration. """
+    # TODO: Show the migrations and their records for any db_alias rather than just the one.
     migration = store.by_key.get(key)
-    db_alias = request.GET.get("db_alias", None)
     record = MigrationRecord.objects.using(db_alias).filter(key=key).first()
     dependencies = []
     dependency_keys = [MigrationRecord.key_from_name_tuple(x) for x in migration.dependencies]
@@ -94,11 +93,9 @@ def migration_detail(request, key):
 
 
 @superuser_required()
-def delete_migration(request, key):
+def delete_migration(request, key, db_alias):
     """ Delete a migration which has already started or has errored. """
     migration = store.by_key.get(key)
-    db_alias = request.GET.get("db_alias", None)
-
     record = migration.get_migration_record(db_alias)
     if not migration:
         raise Http404(f"Migration with key {key} for db {db_alias} not found.")

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -44,9 +44,11 @@ def manage_migrations(request):
 def run_migration(request, key, db_alias):
     """ Trigger the running of a migration. """
     migration = store.by_key.get(key)
-    record = migration.get_migration_record(db_alias)
     if not migration:
         raise Http404(f"Migration with key '{key}' not found.")
+
+    record = migration.get_migration_record(db_alias)
+
     if record:
         messages.error(request, f"Migration '{key}' has already been started.")
         return redirect("massmigration_manage")
@@ -73,6 +75,9 @@ def migration_detail(request, key, db_alias):
     """ View the details of a single migration. """
     # TODO: Show the migrations and their records for any db_alias rather than just the one.
     migration = store.by_key.get(key)
+    if not migration:
+        raise Http404(f"Migration with key {key} for db {db_alias} not found.")
+
     record = MigrationRecord.objects.using(db_alias).filter(key=key).first()
     dependencies = []
     dependency_keys = [MigrationRecord.key_from_name_tuple(x) for x in migration.dependencies]
@@ -96,9 +101,11 @@ def migration_detail(request, key, db_alias):
 def delete_migration(request, key, db_alias):
     """ Delete a migration which has already started or has errored. """
     migration = store.by_key.get(key)
-    record = migration.get_migration_record(db_alias)
     if not migration:
         raise Http404(f"Migration with key {key} for db {db_alias} not found.")
+
+    record = migration.get_migration_record(db_alias)
+
     if not record:
         messages.error(
             request,

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -52,7 +52,7 @@ def run_migration(request, key):
         messages.error(request, f"Migration '{key}' has already been started.")
         return redirect("massmigration_manage")
     try:
-        migration.check_dependencies()
+        migration.check_dependencies(db_alias)
     except DependentMigrationNotApplied as error:
         messages.error(request, str(error))
         return redirect("massmigration_manage")

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -30,7 +30,7 @@ def manage_migrations(request):
         for db_alias in available_db_aliases:
             migration.records_map[db_alias] = {
                 "is_allowed_on_db_alias": db_alias in migration.get_allowed_db_aliases(),
-                "record": migration_records_by_db_alias.get(db_alias, None).get(migration.key, None)
+                "record": migration_records_by_db_alias.get(db_alias).get(migration.key, None)
             }
 
     context = {

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -30,7 +30,7 @@ def manage_migrations(request):
         for db_alias in available_db_aliases:
             migration.records_map[db_alias] = {
                 "is_allowed_on_db_alias": db_alias in migration.get_allowed_database_aliases(),
-                "record": migration_records_by_db_alias.get(db_alias, None)
+                "record": migration_records_by_db_alias.get(db_alias, None).get(migration.key, None)
             }
 
     context = {

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -29,7 +29,7 @@ def manage_migrations(request):
 
         for db_alias in available_db_aliases:
             migration.records_map[db_alias] = {
-                "is_allowed_on_db_alias": db_alias in migration.get_allowed_database_aliases(),
+                "is_allowed_on_db_alias": db_alias in migration.get_allowed_db_aliases(),
                 "record": migration_records_by_db_alias.get(db_alias, None).get(migration.key, None)
             }
 

--- a/massmigration/views.py
+++ b/massmigration/views.py
@@ -95,7 +95,6 @@ def migration_detail(request, key, db_alias):
         "record": record,
         "dependencies": dependencies,
         "db_alias": db_alias,
-
     }
     return render(request, "massmigration/migration_detail.html", context)
 


### PR DESCRIPTION
This is about implementing multi db support taking a different approach. 
The original [PR](https://github.com/adamalton/django-mass-migration/pull/1/files) kept a 1to1 relationship between `Migration` and `MigrationRecords` while here we do keep one migration and create different records for different DBs.

## Assumptions
- Records are stored in the same DB the migration is applied to.\



## To be tackled in different tickets
While not necessarely hard to implement, I prefer to keep this PR focussed and tackled the following improvements in separate PRs.

- Migration detail should show migrations on any DB rather than being detail of a (migration, db_alias).
- We should allow to specify cross database dependencies. 